### PR TITLE
Fix broken build

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,8 @@
   caqti
   caqti-lwt
   caqti-driver-postgresql
-  jose
+  (jose
+    (<= "0.6.0"))
   fileutils
   lwt_ppx
   ppx_yojson_conv

--- a/dune-project
+++ b/dune-project
@@ -37,6 +37,7 @@
   ppx_let
   ocamlformat
   ppx_rapper
+  ppx_rapper_lwt
   jingoo))
 
 (package

--- a/ocoi.opam
+++ b/ocoi.opam
@@ -17,7 +17,7 @@ depends: [
   "caqti"
   "caqti-lwt"
   "caqti-driver-postgresql"
-  "jose"
+  "jose" {<= "0.6.0"}
   "fileutils"
   "lwt_ppx"
   "ppx_yojson_conv"

--- a/ocoi.opam
+++ b/ocoi.opam
@@ -25,6 +25,7 @@ depends: [
   "ppx_let"
   "ocamlformat"
   "ppx_rapper"
+  "ppx_rapper_lwt"
   "jingoo"
 ]
 build: [

--- a/ocoi/bin/dune
+++ b/ocoi/bin/dune
@@ -2,7 +2,7 @@
  (names ocoi)
  (public_names ocoi)
  (libraries core compiler-libs.common fileutils lwt lwt.unix str
-   ppx_rapper.runtime caqti-driver-postgresql ptime.clock.os)
+   ppx_rapper.runtime ppx_rapper_lwt caqti-driver-postgresql ptime.clock.os)
  (preprocess
   (pps ppx_optcomp ppx_let lwt_ppx ppxlib.metaquot ppx_rapper))
  (package ocoi))


### PR DESCRIPTION
Hi,
I tried to build ocoi, but there were some issues. The build broke with the latest `jose` dependency so I pinned it to `0.6.0` in order to get rid of the compilation failures. I may fix the broken places later, but for now I just set the version straight.

`ppx_rapper` seems to also require `ppx_rapper_lwt`, adding this dependency fixed the rest of the issues.
With these changes, I successfully built the project with OCaml `4.08.1`
`4.14.0` cause more issues regarding `Core` module, I didn't do anything about those for now.

